### PR TITLE
:memo: add documentation to `EspansoMatch` and update `flutter_lints`

### DIFF
--- a/lib/Match/match_class.dart
+++ b/lib/Match/match_class.dart
@@ -61,31 +61,47 @@ class EspansoMatches {
   }
 }
 
+/// Basic class of a Espanso Match
 class EspansoMatch {
+  /// string to trigger expansion
   String? trigger;
+
+  /// what the trigger expands to
   String replace;
+
+  ///
   String label;
+
+  /// alternative to replace, opens a form to fill out
   bool form;
+
+  /// ex. alh - although, Alh - Although, ALH - ALTHOUGH
   bool propagateCase;
+
+  /// if propagateCase should capitalise each word. `false` by default
   bool capitaliseEachWord;
+
+  /// only trigger on matching word
   bool triggerOnWord;
+
+  /// list of variables
   List<dynamic>? vars;
+
+  /// optional arguments for form fields
   Map<String, EspansoFormField>? formFields;
-  //add cursor hints functionality
-  //add image functionality
+  // TODO: add cursor hints functionality
+  // TODO: add image functionality
 
   EspansoMatch({
-    this.trigger, // string to trigger expansion
-    this.replace = '', //what the trigger expands to
-    this.form = false, //alternative to replace, opens a form to fill out
-    this.label = '', //description for match
-    this.propagateCase =
-        false, //ex. alh - although, Alh - Although, ALH - ALTHOUGH
-    this.capitaliseEachWord =
-        false, //if propagateCase should capitalise each word
-    this.triggerOnWord = false, //only trigger on matching word
-    this.vars, //list of variables
-    this.formFields, //optional arguments for form fields
+    this.trigger,
+    this.replace = '',
+    this.label = '',
+    this.form = false,
+    this.propagateCase = false,
+    this.capitaliseEachWord = false,
+    this.triggerOnWord = false,
+    this.vars,
+    this.formFields,
   });
 
   factory EspansoMatch.fromYaml(YamlMap yaml) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,10 +90,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "3.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -131,38 +131,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   logging:
     dependency: transitive
     description:
@@ -175,34 +151,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   pointycastle:
     dependency: transitive
     description:
@@ -288,22 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad"
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.3.0"
   yaml:
     dependency: "direct main"
     description:
@@ -321,4 +289,4 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^3.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Hi! I wanted to get my hands dirty and I added a few little lines to document `EspansoMatch`

TIL that `dart doc` is a command that generates html documentation to read the code, much like `cargo doc` happens in rust. Love it! ❤️ 

Also, as I was already there, upgraded `flutter_lints` to 3.0

Please flag any issue you want to fix before merging! 😄 